### PR TITLE
Endpoint para cerrar votación

### DIFF
--- a/app/models/radar_template_container.rb
+++ b/app/models/radar_template_container.rb
@@ -1,5 +1,7 @@
 class RadarTemplateContainer < ApplicationRecord
   CANNOT_HAVE_MORE_THAN_ONE_ACTIVE_VOTING_ERROR_MESSAGE = "No puede haber mas de una votación activa al mismo tiempo"
+  NO_ACTIVE_VOTING = 'No se encontró ninguna votación abierta'
+  CONTAINER_NOT_FOUND_ERROR = 'No se encontró el radar template container'
 
   include Ownerable
   has_many :radar_templates, -> { order(created_at: :asc) }
@@ -41,5 +43,13 @@ class RadarTemplateContainer < ApplicationRecord
     validate_ownership! owner
     update!(active: false)
     radar_templates.each { |rt| rt.close owner }
+  end
+
+  def close_active_voting(logged_user)
+    raise ActiveRecord::RecordNotFound.new(CONTAINER_NOT_FOUND_ERROR) unless is_known_by?(logged_user)
+    voting = active_voting
+    raise ActiveRecord::RecordNotFound.new(NO_ACTIVE_VOTING) unless voting.present?
+    voting.update!(ends_at: DateTime.now)
+    voting
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
   end
 
   get 'api/votings', to: "votings#show_by_code"
+  put 'api/votings/:radar_template_container_id', to: "votings#close"
 
   get 'auth/:provider/callback', to: "omni_auth#callback"
   get 'auth/:provider/redirect', to: "omni_auth#redirect"

--- a/spec/controllers/votings_controller_spec.rb
+++ b/spec/controllers/votings_controller_spec.rb
@@ -168,6 +168,37 @@ RSpec.describe VotingsController, type: :controller do
 
   end
 
+  describe "#close" do
+    subject do
+      put :close, params: {radar_template_container_id: a_radar_template_container.id}
+    end
+
+    context 'when there are no active votings' do
+      it 'the request returns not found' do
+        expect(subject).to have_http_status :not_found
+      end
+    end
+
+      context 'when there radar template container is non existent' do
+        subject do
+          put :close, params: {radar_template_container_id: -1}
+        end
+
+        it 'the request returns not found' do
+          expect(subject).to have_http_status :not_found
+        end
+      end
+
+    context 'when the voting is active' do
+      let(:voting) { Voting.generate!(a_radar_template_container, "A name", DateTime.now + 5.days)}
+
+      it 'the voting is successfully closed' do
+        expect(subject).to have_http_status :ok
+        expect(voting.active?).to eq(false)
+      end
+    end
+  end
+
 
 
 end

--- a/spec/controllers/votings_controller_spec.rb
+++ b/spec/controllers/votings_controller_spec.rb
@@ -188,13 +188,27 @@ RSpec.describe VotingsController, type: :controller do
       end
     end
 
-    context 'when there is an active voting' do
+    context 'when there is an active voting associated to the container' do
       let!(:voting) { Voting.generate!(a_radar_template_container, "A name", DateTime.now + 5.days)}
+
 
       it 'the voting is successfully closed' do
         expect(subject).to have_http_status :ok
         expect(voting.reload.active?).to eq(false)
         expect(voting.ends_at).to eq(DateTime.now)
+      end
+    end
+
+    context 'when the user doesn\'t know the container' do
+      let!(:voting) { Voting.generate!(a_radar_template_container, "A name", ends_at)}
+      before do
+        allow(JWT).to receive(:decode).and_return [another_user.as_json]
+      end
+
+      it 'the request should be unsuccessful with a not found status' do
+        expect(subject).to have_http_status :not_found
+        expect(voting.reload.active?).to eq(true)
+        expect(voting.ends_at).to eq(ends_at)
       end
     end
   end

--- a/spec/controllers/votings_controller_spec.rb
+++ b/spec/controllers/votings_controller_spec.rb
@@ -169,8 +169,9 @@ RSpec.describe VotingsController, type: :controller do
   end
 
   describe "#close" do
+    let(:body_params){{radar_template_container_id: a_radar_template_container.id}}
     subject do
-      put :close, params: {radar_template_container_id: a_radar_template_container.id}
+      put :close, params: body_params
     end
 
     context 'when there are no active votings' do
@@ -179,22 +180,21 @@ RSpec.describe VotingsController, type: :controller do
       end
     end
 
-      context 'when there radar template container is non existent' do
-        subject do
-          put :close, params: {radar_template_container_id: -1}
-        end
+    context 'when the radar template container is non existent' do
+      let(:body_params){{radar_template_container_id: -1}}
 
-        it 'the request returns not found' do
-          expect(subject).to have_http_status :not_found
-        end
+      it 'the request returns not found' do
+        expect(subject).to have_http_status :not_found
       end
+    end
 
-    context 'when the voting is active' do
-      let(:voting) { Voting.generate!(a_radar_template_container, "A name", DateTime.now + 5.days)}
+    context 'when there is an active voting' do
+      let!(:voting) { Voting.generate!(a_radar_template_container, "A name", DateTime.now + 5.days)}
 
       it 'the voting is successfully closed' do
         expect(subject).to have_http_status :ok
-        expect(voting.active?).to eq(false)
+        expect(voting.reload.active?).to eq(false)
+        expect(voting.ends_at).to eq(DateTime.now)
       end
     end
   end

--- a/spec/controllers/votings_controller_spec.rb
+++ b/spec/controllers/votings_controller_spec.rb
@@ -188,17 +188,6 @@ RSpec.describe VotingsController, type: :controller do
       end
     end
 
-    context 'when there is an active voting associated to the container' do
-      let!(:voting) { Voting.generate!(a_radar_template_container, "A name", DateTime.now + 5.days)}
-
-
-      it 'the voting is successfully closed' do
-        expect(subject).to have_http_status :ok
-        expect(voting.reload.active?).to eq(false)
-        expect(voting.ends_at).to eq(DateTime.now)
-      end
-    end
-
     context 'when the user doesn\'t know the container' do
       let!(:voting) { Voting.generate!(a_radar_template_container, "A name", ends_at)}
       before do
@@ -207,8 +196,14 @@ RSpec.describe VotingsController, type: :controller do
 
       it 'the request should be unsuccessful with a not found status' do
         expect(subject).to have_http_status :not_found
-        expect(voting.reload.active?).to eq(true)
-        expect(voting.ends_at).to eq(ends_at)
+      end
+    end
+
+    context 'when there is an active voting associated to the container' do
+      let!(:voting) { Voting.generate!(a_radar_template_container, "A name", DateTime.now + 5.days)}
+
+      it 'the voting is successfully closed' do
+        expect(subject).to have_http_status :ok
       end
     end
   end

--- a/spec/models/radar_template_container_spec.rb
+++ b/spec/models/radar_template_container_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe RadarTemplateContainer, type: :model do
-  include ActiveSupport::Testing::TimeHelpers
 
   let(:radar_template_container){create :radar_template_container, owner: owner}
   let(:owner){create :user}

--- a/spec/models/radar_template_container_spec.rb
+++ b/spec/models/radar_template_container_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe RadarTemplateContainer, type: :model do
+  include ActiveSupport::Testing::TimeHelpers
 
   let(:radar_template_container){create :radar_template_container, owner: owner}
   let(:owner){create :user}
@@ -153,5 +154,40 @@ RSpec.describe RadarTemplateContainer, type: :model do
       end
     end
 
+  end
+
+  describe '#close_active_voting' do
+    let(:user){owner}
+    let(:ends_at) {DateTime.now + 5.days}
+    subject do
+      radar_template_container.close_active_voting(user)
+    end
+
+    context 'when there are no active votings' do
+      it 'raises an error with the appropiate message' do
+        expect{ subject }.to raise_error ActiveRecord::RecordNotFound, RadarTemplateContainer::NO_ACTIVE_VOTING
+      end
+    end
+
+    context 'when there is an active voting associated to the container' do
+      let!(:voting) { Voting.generate!(radar_template_container, "A name", ends_at)}
+
+      it 'the voting is successfully closed' do
+        expect(subject.active?).to eq(false)
+      end
+    end
+
+    context 'when the user doesn\'t know the container' do
+      let!(:voting) { Voting.generate!(radar_template_container, "A name", ends_at)}
+      let(:user){another_user}
+      before do
+        allow(JWT).to receive(:decode).and_return [another_user.as_json]
+      end
+
+      it 'the request should be unsuccessful with a not found status' do
+        expect{ subject }.to raise_error ActiveRecord::RecordNotFound, RadarTemplateContainer::CONTAINER_NOT_FOUND_ERROR
+        expect(voting.reload.active?).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
Agrega método close en el controlador de Votings y un endpoint en routes para realizar la acción de cerrar una votación. PR asociado con pr homónimo en frontend.