### PR TITLE
fix de voting ends_at válido

### DIFF
--- a/app/controllers/votings_controller.rb
+++ b/app/controllers/votings_controller.rb
@@ -8,7 +8,7 @@ class VotingsController < ApplicationController
     radar_template_container = RadarTemplateContainer.find(params.require(:radar_template_container_id))
     if radar_template_container && radar_template_container.is_known_by?(@logged_user)
       name = params.permit(:name)['name']
-      ends_at = DateTime.parse(params.require(:ends_at))
+      ends_at = DateTime.parse(params.require(:ends_at)).end_of_day
 
       voting = Voting.generate!(radar_template_container, name, ends_at)
       render json: voting, logged_user: @logged_user, status: :created

--- a/spec/controllers/votings_controller_spec.rb
+++ b/spec/controllers/votings_controller_spec.rb
@@ -130,6 +130,14 @@ RSpec.describe VotingsController, type: :controller do
         expect(subject).to have_http_status :not_found
       end
     end
+
+    #este test verifica que se permitan crear votings  que como fecha de ends_at tienen el día actual
+    context 'when the voting\'s ends_at date is today, the voting is created successfully' do
+      let(:ends_at) { DateTime.now }
+      it 'the request succeeds with created status' do
+        expect(subject).to have_http_status :created
+      end
+    end
   end
 
   describe "#show_by_code" do


### PR DESCRIPTION
Cambia ends_at de voting de manera que se guarde un datetime con la fecha con la que viene de frontend y momento como 'final del día' de tal fecha. De esta manera, ya no tira error cuando el usuario crea un voting fecha actual de ends_at.