### PR TITLE
agrega atributo promedio global al radar serializado

### DIFF
--- a/app/models/radar.rb
+++ b/app/models/radar.rb
@@ -29,6 +29,15 @@ class Radar < ApplicationRecord
     active
   end
 
+  def global_average
+    points = answers.map { |answer| answer.points}
+    total_sum = points.inject(:+)
+    num_points = points.length
+    global_average = 0
+    global_average = total_sum.to_f / num_points unless num_points == 0
+    global_average
+  end
+
   private
 
   def assert_active_radar

--- a/app/serializers/radar_serializer.rb
+++ b/app/serializers/radar_serializer.rb
@@ -1,5 +1,5 @@
 class RadarSerializer < ActiveModel::Serializer
-  attributes :id, :active, :name, :description, :created_at, :axes
+  attributes :id, :active, :name, :description, :created_at, :axes, :global_average
 
   def axes
     object.axes.map do |axis|
@@ -7,4 +7,9 @@ class RadarSerializer < ActiveModel::Serializer
       AxisSerializer.new(axis).as_json.merge({answers: answers})
     end
   end
+
+  def global_average
+    object.global_average
+  end
+
 end

--- a/spec/controllers/radars_controller_spec.rb
+++ b/spec/controllers/radars_controller_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe RadarsController, type: :controller do
       'name' => radar.name,
       'description' => radar.description,
       'active' => radar.active,
-      'created_at' => radar.created_at.as_json
+      'created_at' => radar.created_at.as_json,
+      'global_average' => radar.global_average
     }
   end
 

--- a/spec/controllers/votings_controller_spec.rb
+++ b/spec/controllers/votings_controller_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe VotingsController, type: :controller do
         'name' => radar.name,
         'description' => radar.description,
         'active' => radar.active,
-        'created_at' => radar.created_at.as_json
+        'created_at' => radar.created_at.as_json,
+        'global_average' => radar.global_average
     }
   end
 


### PR DESCRIPTION
Se agrega la data de promedio de todos los votos al serializador de radar. Para calcular ese promedio, se agrega método homónimo en el modelo de Radar.